### PR TITLE
[script][dusk-labyrinth.lic] handle maze reset instead of exiting

### DIFF
--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -135,7 +135,8 @@ class DuskLab
         break(true)
       end
     end
-    return if success 
+    return if success
+
     DRC.message('Unable to move to another room after maze shuffled')
     DRC.message('Try to move yourself to another room then restart script')
     exit

--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -130,11 +130,12 @@ class DuskLab
   # Randomly move in directions until one works.
   def wander_randomly
     DRC.message("Maze reshuffled, trying to find a direction to move to")
-    ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'].each do |dir|
+    success = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'].each do |dir|
       if move(dir)
-        return
+        break(true)
       end
     end
+    return if success 
     DRC.message('Unable to move to another room after maze shuffled')
     DRC.message('Try to move yourself to another room then restart script')
     exit

--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -132,7 +132,7 @@ class DuskLab
     DRC.message("Maze reshuffled, trying to find a direction to move to")
     ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'].each do |dir|
       if move(dir)
-        break
+        return
       end
     end
     DRC.message('Unable to move to another room after maze shuffled')


### PR DESCRIPTION
When maze shuffles, existing behavior was to print a message and exit.   This change allows script to handle this shuffle and begin mapping again.